### PR TITLE
Add exemption text

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,12 @@
                         <a href="https://www.congress.gov/118/plaws/publ187/PLAW-118publ187.pdf" target="_blank"
                             class="doc-link">View Text <span aria-hidden="true">→</span></a>
                     </div>
+                    <div class="doc-card">
+                        <h3>Exemptions</h3>
+                        <p>Link to sign off on risk acceptance of open-sourcing the software product documentation</p>
+                        <a href="https://github.com/DSACMS/gov-codejson/blob/main/docs/exemptions.md" target="_blank"
+                            class="doc-link">View Text <span aria-hidden="true">→</span></a>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Problem
Exemption text missing from SHARE IT landing page.

## Solution
Add `Exemption.md` link to `index.html` LN: 198

## Result 
File is now visible in browser

## Test
Tested manually in `index.html`