### PR TITLE
Add glossary to SHARE IT

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,12 @@
                         <a href="https://github.com/DSACMS/gov-codejson/blob/main/docs/exemptions.md" target="_blank"
                             class="doc-link">View Text <span aria-hidden="true">→</span></a>
                     </div>
+                    <div class="doc-card">
+                        <h3>Glossary</h3>
+                        <p>Link to Glossary of Helpful Terms in the SHARE IT Act</p>
+                        <a href="https://dsacms.github.io/ospo-guide/resources/glossary/" target="_blank"
+                            class="doc-link">View Text <span aria-hidden="true">→</span></a>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Problem
It would be helpful to have terms explained in SHARE IT

## Solution
Create a glossary within OSPO Guide and link to it as a card in SHARE IT

## Result
Glossary is now accessible in SHARE IT

## Test
Test in browser