### PR TITLE
Add definitions to tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <title>SHARE IT Act | Centers for Medicare & Medicaid Services</title>
     <link rel="icon" type="image/x-icon" href="assets/images/dsacms.svg">
     <meta name="description"
-        content="Guide to the Source Code Harmonization And Reuse in Information Technology Act - SHARE IT Act - Helping federal agencies comply with software code sharing requirements.">
+        content="Guide to the Source Code Harmonization And Reuse in Information Technology Act - 
+        SHARE IT Act - Helping federal agencies comply with software code sharing requirements.">
     <link rel="stylesheet" href="assets/css/styles.css">
     <script src="assets/js/main.js" defer></script>
 
@@ -88,25 +89,49 @@
                     <h2 id="features-heading">What is the SHARE IT Act?</h2>
 
                     <p id="features-body"> <em>"This bill requires federal agencies to ensure that custom-developed code
-                            (i.e., source code that
+                            (i.e., <a href="https://dsacms.github.io/ospo-guide/resources/glossary/#source-code" class="usa-tooltip" 
+                            data-position="top"
+                            title="Source code: Computer commands written in a computer programming language that is meant to be read by people. Generally, source 
+                            code is a higher level representation of computer commands as they are written by people and, therefore, must be assembled or compiled 
+                            before a computer can execute the code as a program."
+                            style="text-decoration: underline #000 dotted; font-size: 1em; color: inherit;">source code</a> that
                             is produced under an agency contract, funded exclusively by the federal government, or
                             developed
                             by federal employees as part of their official duties) and certain technical components of
                             the
-                            code such as architecture designs and metadata are
+                            code such as architecture designs and <a href="https://dsacms.github.io/ospo-guide/resources/glossary/#metadata" class="usa-tooltip" data-position="top"
+                            title="Metadata: Data about data, or, data that describes other data. A key example would be the information that you see in the file explorer or Finder 
+                            on a computer, such as date modified, file size, and file type. For the SHARE IT Act, metadata about the software, such as repository location, feedback 
+                            mechanisms, and related ContractID(s), and contact information about the developers."
+                            style="text-decoration: underline #000 dotted; font-size: 1em; color: inherit;">metadata</a> are
                             <br><br>
 
                             <strong>(1)</strong> owned by the agency, <br>
-                            <strong>(2)</strong> stored at no less than one public or private repository, and <br>
+                            <strong>(2)</strong> stored at no less than one public or private <a href="https://dsacms.github.io/ospo-guide/resources/glossary/#repository" 
+                            class="usa-tooltip" data-position="top"
+                            title="Repository: Also known as “repo” A repository is the most basic element of GitHub. They're easiest to imagine as a project's folder. 
+                            A repository contains all of the project files (including documentation), and stores each file's revision history. Repositories can have multiple collaborators and 
+                            can be either public or private."
+                            style="text-decoration: underline #000 dotted; font-size: 1em; color: inherit;">repository</a>, and <br>
                             <strong>(3)</strong> accessible to federal employees under certain procedures. Agency
                             contracts for
-                            custom-development of software must acquire and exercise rights sufficient to allow
-                            government-wide access, sharing, use, and modification of any custom-developed code.
+                            custom-development of <a href="https://dsacms.github.io/ospo-guide/resources/glossary/#software" class="usa-tooltip" data-position="top"
+                            title="Software: Refers to (i) computer programs that comprise a series of instructions, rules, routines, or statements, regardless of the media in which recorded, 
+                            that allow or cause a computer to perform a specific operation or series of operations; and (ii) recorded information comprising source code listings, design details, 
+                            algorithms, processes, flow charts, formulas, and related material that would enable the computer program to be produced, created, or compiled."
+                            style="text-decoration: underline #000 dotted; font-size: 1em; color: inherit;">software</a> must acquire and exercise rights sufficient to allow
+                            government-wide access, sharing, <a href="https://dsacms.github.io/ospo-guide/resources/glossary/#software-reuse" class="usa-tooltip" data-position="top"
+                            title="Software reuse: The practice of using existing software components, modules, or code to build new applications, rather than writing everything from scratch."
+                            style="text-decoration: underline #000 dotted; font-size: 1em; color: inherit;">use</a>, and modification of any custom-developed code.
                             <br><br>
 
                             The bill does not apply to source code that is classified, developed primarily for use in a
                             national security system, or developed by an element of the intelligence community.
-                            An agency's office of the chief information officer may exempt source code from being shared
+                            An agency's office of the chief information officer may <a href="https://github.com/DSACMS/gov-codejson/blob/main/docs/exemptions.md" class="usa-tooltip" 
+                            data-position="top"
+                            title="Exemptions: Conditions defined by the SHARE IT Act or related regulations that prevent a code repository from being publicly released due to legal, 
+                            security, privacy, or export control restrictions."
+                            style="text-decoration: underline #000 dotted; font-size: 1em; color: inherit;">exempt</a> source code from being shared
                             or made publicly accessible to protect individual privacy."
                             <a href="https://www.congress.gov/bill/118th-congress/house-bill/9566">Bill Summary</a>
                         </em>


### PR DESCRIPTION
## Problem
When hovering over words that need definitions in the SHARE IT landing page, no definitions appear. 

## Solution
Use USWDS to create tooltips and links to relevant terms and links

## Result
When hovering over words in need of definitions, a definition pops-up over the word and links to the correct page

## Test
Test in browser

## Next Steps
Break definitions into a separate JS file to create dynamic tooltips