### PR TITLE
Dk/content about

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -24,6 +24,6 @@ codegov:
     url: /about/
     children:
       - name: FAQ
-        url: FAQ/
+        url: /about/FAQ/
       - name: Glossary
-        url: glossary/
+        url: /about/glossary/

--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -24,6 +24,6 @@ codegov:
     url: /about/
     children:
       - name: FAQ
-        url: /FAQ/
+        url: FAQ/
       - name: Glossary
-        url: /glossary/
+        url: glossary/

--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -1,19 +1,17 @@
 ---
 title: Frequently Asked Questions (FAQs)
 description: 'Frequently Asked Questions'
-permalink: /about/faq
+permalink: /about/FAQ/
 layout: layouts/page
-tags: codegov
+tags: shareit
 eleventyNavigation:
-  parent: codegov-about
-  key: codegov-about-faq
+  parent: shareit-about
+  key: shareit-about-faq
   order: 3
   title: Frequently Asked Questions
 sidenav: true
 sticky_sidenav: true
 ---
-
-# Frequently Asked Questions (FAQs)
 
 ## Policies
 

--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -1,0 +1,92 @@
+---
+title: Frequently Asked Questions (FAQs)
+description: 'Frequently Asked Questions'
+permalink: /about/faq
+layout: layouts/page
+tags: codegov
+eleventyNavigation:
+  parent: codegov-about
+  key: codegov-about-faq
+  order: 3
+  title: Frequently Asked Questions
+sidenav: true
+sticky_sidenav: true
+---
+
+# Frequently Asked Questions (FAQs)
+
+## Policies
+
+### What is the Federal Source Code Policy / M-16-21?
+
+The Federal Source Code Policy (M-16-21) is a policy issued by the U.S. government that aims to improve software reuse and collaboration across federal agencies. It requires agencies to:
+
+- Create an inventory of their custom developed code.
+- Share code within and across agencies to reduce duplication and costs.
+- Maintain metadata records of their software assets for transparency and tracking.
+
+### What is the SHARE IT Act of 2024?
+
+The SHARE IT Act of 2024 is legislation designed to enhance transparency, collaboration, and efficiency in government software development. It mandates:
+
+- Greater adoption of open source software in federal agencies.
+- Improved sharing of government software projects with the public.
+- Standardized reporting on software development and licensing practices.
+- Establishment of metadata guidelines to ensure clear documentation and discoverability of software assets.
+
+Learn more at: https://dsacms.github.io/share-it-act-lp/
+
+### Does the SHARE IT Act also apply retroactively to previous custom-developed code?
+
+No. The SHARE IT Act applies only to custom-developed code created on or after July 21, 2025. Code developed prior to this date is not subject to its requirements, however, code created after August 8, 2016 is subject to the Federal Source Code Policy.
+
+### Are there any source code exemptions under the SHARE IT Act?
+
+There are [4 exemptions](https://www.congress.gov/bill/118th-congress/house-bill/9566/text/ih#HB45699B7E8734166BE2F6DA2A80F7909):
+
+1. Source code developed primarily for use in a national security system
+2. Source code developed by an agency, or part of an agency, that is an element of the intelligence community
+3. Source code that falls under the Freedom of Information Act
+4. Source code identified by the agency’s CIO
+
+### Does SHARE IT Act apply to data analysis code?
+
+Yes. All custom-developed code—whether it involves software applications, data analysis, infrastructure/devops, interoperability, or internal tools/scripts—must reside in a repository, unless it qualifies for one of the [four exemptions](https://www.congress.gov/bill/118th-congress/house-bill/9566/text/ih#HB45699B7E8734166BE2F6DA2A80F7909).
+
+### When do agencies have to comply?
+The SHARE IT Act applies to custom-developed code created on or after July 21, 2025 where agencies must:
+- store custom-developed code in a repository
+- ensure code is accessible to federal employees and is owned by the agency
+- publish metadata on all custom-developed code
+
+## code.json Metadata Standard
+
+### What is code.json?
+
+`code.json` is a metadata file used by U.S. federal agencies to document and share their software projects. It provides:
+
+- A standardized format for describing open source and custom developed software.
+- Key details such as the project's name, description, license, repository URL, and labor hours.
+- Integration with government wide platforms to facilitate code sharing and reuse.
+
+### Why is code.json important?
+
+By collecting metadata on every software project, this allows the agency to build a comprehensive inventory of agency software, enabling strategic decisions about cost reduction and efficiencies through reuse of code.
+
+### Is code.json mandatory for all repositories?
+
+Yes. As per M-16-21, agencies are required to publish metadata on all custom-developed code after August 8th 2016, which is not subject to exemptions (see: Sec 6 of [M-16-21](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf)).
+
+As per the SHARE IT Act, agencies are required to publish metadata on all custom-developed code after July 22, 2025, which is not subject to exemptions (see: [SHARE IT ACT exemptions](https://www.congress.gov/118/plaws/publ187/PLAW-118publ187.pdf)).
+
+### I have feedback on additions and improvements to the code.json metadata standard. Where can I share this?
+
+We are open to adding more fields to CMS code.json for any metadata the agency sees value in collecting. Request new metadata fields by filing a metadata field addition issue [here](https://github.com/DSACMS/gov-codejson/issues/new?template=metadata-field-addition.md).
+
+### My agency extended the code.json schema to add more metadata fields. Where can I share this?
+
+We encourage agencies to contribute by [submitting an agency schema addition issue](https://github.com/DSACMS/gov-codejson/issues) to [include their extended schema in the repository](../schemas). This helps foster collaboration and ensures shared improvements benefit the wider community.
+
+### Does `laborHours` need to be down-to-the-minute accurate?
+
+The goal is to be as accurate as we can, and with as little burden as possible. We strive to automate labor hour calculations for public repositories whenever possible (using the [scc](https://github.com/boyter/scc) tool), but manual ballpark estimates are acceptable when precise calculation isn't feasible.

--- a/content/about/glossary.md
+++ b/content/about/glossary.md
@@ -1,0 +1,62 @@
+---
+title: Glossary
+description: 'A glossary of definitions for frequently asked words and phrases'
+permalink: /about/glossary/
+layout: layouts/page
+tags: ospo
+eleventyNavigation:
+  parent: about
+  key: shareit-about-glossary
+  order: 2
+  title: Glossary
+sidenav: true
+sticky_sidenav: true
+---
+
+### CI/CD
+Abbreviation for “Continuous Integration/Continuous deployment”. This is the practice of creating tools that automatically run that help with the development and maintenance of a software project whenever the source code changes. Integration usually takes the form of automatically running tests and/or checks on proposed changes to the source code. The continuous deployment side of things takes the form of automatically deploying, copying, or moving the code, whenever it passes key checks and approvals.
+
+### Code.json
+A metadata file used by U.S. federal agencies to document and share software projects. It provides a standardized format for describing open source and custom developed software.
+
+### Code.gov
+This platform is primarily intended to serve two distinct functions. First, it will act as an online collection of tools, guides, and best practices specifically designed to help agencies implement the framework presented in this policy. Second, it will serve as the primary discoverability portal for custom-developed code intended both for Government-wide reuse and for potential release as OSS. Code.gov is not intended to house the custom-developed code itself; rather, it is intended to serve as a tool for discovering custom-developed code that may be available for Government-wide reuse or as OSS, and to provide transparency into custom developed code that is developed using Federal funds. This discoverability portal will be publicly accessible and searchable via a variety of fields and constraints, such as the name of the project, its intended use, and the agency releasing the source code. Code.gov will be accessible at https://www.code.gov and will evolve over time as a community resource to facilitate the adoption of good custom source code development, sharing, and reuse practices.
+
+### Custom Developed code
+For the purposes of this policy, custom-developed code is code that is first produced in the performance of a Federal contract or is otherwise fully funded by the Federal Government. It includes code, or segregable portions of code, for which the Government could obtain unlimited rights under Federal Acquisition Regulations (FAR) Pt. 27 and relevant agency FAR Supplements. Custom-developed code also includes code developed by agency employees as part of their official duties. For the purposes of this policy, custom-developed code may include, but is not limited to, code written for software projects, modules, plugins, scripts, middleware, and APIs; it does not, however, include code that is truly exploratory or disposable in nature, such as that written by a developer experimenting with a new language or library.
+
+### Exemptions
+Conditions defined by the SHARE IT Act or related regulations that prevent a code repository from being publicly released due to legal, security, privacy, or export control restrictions. See: [EXEMPTIONS.md](https://github.com/DSACMS/gov-codejson/blob/main/docs/exemptions.md)
+
+### GitHub Actions
+GitHub Actions are Github’s method of supporting CI/CD natively on their source code hosting platform. They allow programs to be run on a hosted software project on GitHub in the cloud or elsewhere.
+
+### JSON
+JavaScript Object Notation - is a human-readable standard text-based format for representing structured data. It is based on JavaScript object syntax, and commonly used for transmitting data in web applications.
+
+### Metadata
+Data about data, or, data that describes other data. A key example would be the information that you see in the file explorer or Finder on a computer, such as date modified, file size, and file type. For the SHARE IT Act, metadata about the software, such as repository location, feedback mechanisms, and related ContractID(s), and contact information about the developers.
+
+### Open Source Software (OSS)
+Software that can be accessed, used, modified, and shared by anyone. OSS is often distributed under licenses that comply with the definition of “Open Source” provided by the Open Source Initiative (https://opensource.org/osd) and/or that meet the definition of “Free Software” provided by the Free Software Foundation (https://www.gnu.org/philosophy/free-sw.html).
+
+### [Publiccode.yml](https://yml.publiccode.tools/)
+A metadata file used by National and International Governmental Organizations to document and share public software developed or acquired by a Public Administration. 
+
+### Repository
+Also known as “repo” A repository is the most basic element of GitHub. They're easiest to imagine as a project's folder. A repository contains all of the project files (including documentation), and stores each file's revision history. Repositories can have multiple collaborators and can be either public or private.
+
+### Repository Scaffolder
+Repository Scaffolder or repo-scaffolder for short is a suite of tools that helps projects create source code repositories that are compliant with Federal standards and guidelines and industry best practices.
+
+### Schema
+The structure of how data is organized. This can be the structure of anything as big as a database to something as small as a file. For SHARE IT purposes, schema mostly describes the layout and fields of a code.json file.
+
+### Software
+Refers to (i) computer programs that comprise a series of instructions, rules, routines, or statements, regardless of the media in which recorded, that allow or cause a computer to perform a specific operation or series of operations; and (ii) recorded information comprising source code listings, design details, algorithms, processes, flow charts, formulas, and related material that would enable the computer program to be produced, created, or compiled.
+
+### Software reuse
+The practice of using existing software components, modules, or code to build new applications, rather than writing everything from scratch.
+ 
+### Source code
+Computer commands written in a computer programming language that is meant to be read by people. Generally, source code is a higher level representation of computer commands as they are written by people and, therefore, must be assembled or compiled before a computer can execute the code as a program.

--- a/content/about/glossary.md
+++ b/content/about/glossary.md
@@ -1,11 +1,11 @@
 ---
 title: Glossary
 description: 'A glossary of definitions for frequently asked words and phrases'
-permalink: /glossary/
+permalink: /about/glossary/
 layout: layouts/page
-tags: ospo
+tags: shareit
 eleventyNavigation:
-  parent: about
+  parent: shareit-about
   key: shareit-about-glossary
   order: 2
   title: Glossary

--- a/content/about/glossary.md
+++ b/content/about/glossary.md
@@ -1,7 +1,7 @@
 ---
 title: Glossary
 description: 'A glossary of definitions for frequently asked words and phrases'
-permalink: /about/glossary/
+permalink: /glossary/
 layout: layouts/page
 tags: ospo
 eleventyNavigation:

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -13,4 +13,8 @@ sidenav: false
 sticky_sidenav: false
 ---
 
-Agency about
+### Agency about
+
+- **[Frequently Asked Questions (FAQs)](/about/FAQ/)** - Common questions and answers about our software policies and practices.
+- **[Glossary](/about/glossary/)** - Definitions for frequently used words and phrases.
+

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -3,10 +3,10 @@ title: About
 description: 'About'
 permalink: /about/
 layout: layouts/page
-tags: codegov
+tags: shareit
 eleventyNavigation:
-  parent: codegov-about
-  key: codegov-about-main
+  parent: shareit-about
+  key: shareit-about-main
   order: 1
   title: About
 sidenav: false

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -9,11 +9,11 @@ eleventyNavigation:
   key: shareit-about-main
   order: 1
   title: About
-sidenav: false
-sticky_sidenav: false
+sidenav: true
+sticky_sidenav: true
 ---
 
-### Agency about
+### About the SHARE IT Act
 
 - **[Frequently Asked Questions (FAQs)](/about/FAQ/)** - Common questions and answers about our software policies and practices.
 - **[Glossary](/about/glossary/)** - Definitions for frequently used words and phrases.

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,0 +1,16 @@
+---
+title: About
+description: 'About'
+permalink: /about/
+layout: layouts/page
+tags: codegov
+eleventyNavigation:
+  parent: codegov-about
+  key: codegov-about-main
+  order: 1
+  title: About
+sidenav: false
+sticky_sidenav: false
+---
+
+Agency about


### PR DESCRIPTION
## Problem
The SHARE IT site needs 'About', 'FAQ', and 'Glossary' pages. Paths need to lead to these pages

## Solution
- Adjust `_data/navigation.yaml` to reflect correct paths
- Modify `glossary` and `FAQ` to reflect correct paths

## Result
Pages not load correctly

## Next Steps:
Adjust About page to reflect OSPO Guide styling