### PR TITLE
Docs: Add checkbox markdown support using markdown-it-tasks-lists

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,13 +3,14 @@ const { EleventyRenderPlugin } = require("@11ty/eleventy");
 const pluginRss = require('@11ty/eleventy-plugin-rss');
 const pluginNavigation = require('@11ty/eleventy-navigation');
 const markdownIt = require('markdown-it');
+const markdownItTaskLists = require('markdown-it-task-lists');
 const markdownItAttrs = require('markdown-it-attrs');
 const markdownItAnchor = require('markdown-it-anchor');
 const markdownItFootnote = require('markdown-it-footnote');
 const { readableDate, htmlDateString, head, min, filterTagList } = require("./config/filters");
 const { headingLinks } = require("./config/headingLinks");
 const { contrastRatio, humanReadableContrastRatio } = require("./config/wcagColorContrast");
-const privateLinks = require ('./config/privateLinksList.js');
+const privateLinks = require('./config/privateLinksList.js');
 const svgSprite = require("eleventy-plugin-svg-sprite");
 const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const yaml = require("js-yaml");
@@ -28,14 +29,14 @@ module.exports = function (config) {
   config.addPassthroughCopy('robots.txt');
 
   // Copy USWDS init JS so we can load it in HEAD to prevent banner flashing
-  config.addPassthroughCopy({'./node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js'});
+  config.addPassthroughCopy({ './node_modules/@uswds/uswds/dist/js/uswds-init.js': 'assets/js/uswds-init.js' });
 
   // Specific scripts to guides
   config.addPassthroughCopy("./assets/_common/js/*");
   config.addPassthroughCopy("./assets/**/js/*");
 
-  config.addPassthroughCopy({'./assets/_common/_img/favicons/favicon.ico': './favicon.ico' });
-  config.addPassthroughCopy({'./assets/_common/_img/favicons': './img/favicons' });
+  config.addPassthroughCopy({ './assets/_common/_img/favicons/favicon.ico': './favicon.ico' });
+  config.addPassthroughCopy({ './assets/_common/_img/favicons': './img/favicons' });
 
   // Set download paths
   // Place files for download in assets/{guide}/dist/{filename.ext}
@@ -91,7 +92,7 @@ module.exports = function (config) {
     return value.toUpperCase();
   });
 
-  config.addFilter("capitalize", (value) =>{
+  config.addFilter("capitalize", (value) => {
     return value.charAt(0).toUpperCase() + value.slice(1);
   });
 
@@ -118,20 +119,20 @@ module.exports = function (config) {
   }).use(markdownItAnchor, {
     permalink: headingLinks,
     slugify: config.getFilter('slugify'),
-  }).use(markdownItAttrs).use(markdownItFootnote);
+  }).use(markdownItAttrs).use(markdownItFootnote).use(markdownItTaskLists, { label: true });
   config.setLibrary('md', markdownLibrary);
 
   // Override Footnote opener
   markdownLibrary.renderer.rules.footnote_block_open = () => (
-  '<section class="footnotes">\n' +
-  '<ol class="footnotes-list">\n'
+    '<section class="footnotes">\n' +
+    '<ol class="footnotes-list">\n'
   );
 
   // Add icons for links with locked resources and external links
   // https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md
   // Token methods:  https://github.com/markdown-it/markdown-it/blob/master/lib/token.js#L125
   const openDefaultRender = markdownLibrary.renderer.rules.link_open ||
-    function(tokens, idx, options, env, self) {
+    function (tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);
     };
 
@@ -140,10 +141,10 @@ module.exports = function (config) {
     let prefixIcon = '';
     if (privateLinks.some((link) => token.attrGet('href').indexOf(link) >= 0)) {
       prefixIcon = '<span class="usa-sr-only"> 18F only, </span>' +
-                   '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
-                   'aria-hidden="true" role="img">' +
-                   '<use xlink:href="#svg-lock_outline"></use>' +
-                   '</svg>'
+        '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
+        'aria-hidden="true" role="img">' +
+        '<use xlink:href="#svg-lock_outline"></use>' +
+        '</svg>'
     }
 
     // Check for external URLs. External means any site that is not a federal .gov url
@@ -167,7 +168,7 @@ module.exports = function (config) {
   };
 
   const defaultHtmlBlockRender = markdownLibrary.renderer.rules.html_block ||
-    function(tokens, idx, options, env, self) {
+    function (tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);
     };
 
@@ -214,26 +215,26 @@ module.exports = function (config) {
 
   // Also need to add icon links to any html style links
   const inlineHTMLDefaultRender = markdownLibrary.renderer.rules.html_inline ||
-    function(tokens, idx, options, env, self) {
+    function (tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);
     };
 
   const linkOpenRE = /^<a[>\s]/i;
   markdownLibrary.renderer.rules.html_inline = (tokens, idx, options, env, self) => {
-    const token=tokens[idx];
+    const token = tokens[idx];
     if (linkOpenRE.test(token.content) && token.content.includes('http')) {
       let content = token.content;
 
       //Add private link icon
       const hrefRE = /href=\"([^"]*)/;
       // get the matching capture group
-      const contentUrl =  content.match(hrefRE)[1];
+      const contentUrl = content.match(hrefRE)[1];
       if (privateLinks.some((privateLink) => contentUrl.indexOf(privateLink) >= 0)) {
         const prefixIcon = '<span class="usa-sr-only"> 18F only, </span>' +
-                           '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
-                           'aria-hidden="true" role="img">' +
-                           '<use xlink:href="#svg-lock_outline"></use>' +
-                           '</svg>'
+          '<svg class="usa-icon margin-top-2px margin-right-2px top-2px" ' +
+          'aria-hidden="true" role="img">' +
+          '<use xlink:href="#svg-lock_outline"></use>' +
+          '</svg>'
         content = content.replace('>', `> ${prefixIcon}`);
         tokens[idx].content = content;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "esbuild": "^0.24.0",
         "esbuild-sass-plugin": "^3.3.1",
         "luxon": "^2.3.1",
-        "markdown-it-footnote": "^3.0.3"
+        "markdown-it-footnote": "^3.0.3",
+        "markdown-it-task-lists": "^2.1.1"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -6445,6 +6446,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
       "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "esbuild": "^0.24.0",
     "esbuild-sass-plugin": "^3.3.1",
     "luxon": "^2.3.1",
-    "markdown-it-footnote": "^3.0.3"
+    "markdown-it-footnote": "^3.0.3",
+    "markdown-it-task-lists": "^2.1.1"
   },
   "mocha": {
     "timeout": 15000


### PR DESCRIPTION
## Problem
In the exemptions page, I noticed that the checkboxes were not rendering. Shows brackets
<img width="686" height="736" alt="Screenshot 2026-05-11 at 11 48 39 AM" src="https://github.com/user-attachments/assets/47c1d230-7d50-4330-92b5-90f4f5a8ffcc" />

## Solution
Installed and utilizing `markdown-it-task-lists` to render checkboxes

## Result
Checkboxes are rendering as checkboxes, no longer brackets.

## Tests
Check passes, runs locally:
<img width="648" height="580" alt="Screenshot 2026-05-11 at 11 50 36 AM" src="https://github.com/user-attachments/assets/f3c5a955-2d38-45aa-a03d-0558edd8cd33" />
