### PR TITLE
Guides: Add/update description front matter to guides for meta descriptions

### DIFF
--- a/content/about/faq.md
+++ b/content/about/faq.md
@@ -1,6 +1,6 @@
 ---
 title: Frequently Asked Questions (FAQs)
-description: 'Frequently Asked Questions'
+description: Frequently Asked Questions
 permalink: /about/FAQ/
 layout: layouts/page
 tags: shareit

--- a/content/about/glossary.md
+++ b/content/about/glossary.md
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-description: 'A glossary of definitions for frequently asked words and phrases'
+description: A glossary of definitions for frequently asked words and phrases
 permalink: /about/glossary/
 layout: layouts/page
 tags: shareit

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,6 +1,6 @@
 ---
 title: About
-description: 'About'
+description: Learn more about the SHARE IT Act
 permalink: /about/
 layout: layouts/page
 tags: shareit

--- a/content/schema/agency.md
+++ b/content/schema/agency.md
@@ -1,6 +1,6 @@
 ---
 title: agency-index.json
-description: Tools to create and update metadata in repositories
+description: Tools and resources to create an agency index / software inventory
 permalink: /schema/agency-index/
 layout: layouts/page
 tags: shareit


### PR DESCRIPTION
## Guides: Add/update description front matter to guides for meta descriptions

## Problem

As part of search, we would like to add meta descriptions to all of our guides. Currently, some of our guides do not have descriptions or need a description refresh.

## Solution

Add/update description front matter to all guides

## Result

All guides have description front matter, thus will have meta descriptions!

## Test Plan
`npm run dev`