### PR TITLE
Search: Edit link tag to include base URL

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -50,7 +50,7 @@ to modify some of the meta-data for the site, this is the place to do it.
   {% endif %}
 
   <meta property="og:type" content="article" />
-  <link rel="canonical" href="{{ page.url }}" />
+  <link rel="canonical" href="{{ page.url | url }}" />
   <meta property="og:url" content="{{ page.url }}" />
   <script async="" src={{ "/assets/js/uswds-init.js" | url }}></script>
 


### PR DESCRIPTION
## Search: Edit link tag to include base URL

## Problem

Flagged by the search.gov team, search is indexing through `dsacms.github.io/` URL so it returns results for all our dsacms.github.io websites. The behavior we would like is to index through only the SHARE IT Act website content - `dsacms.github.io/share-it-act-lp` 

## Solution

Add url filter to `page.url` so it appends the base URL (share-it-act-lp) to the href in the link tag.

## Result

Search will crawl and index through `dsacms.github.io/share-it-act-lp` as the root.